### PR TITLE
`payout` and `withdraw` to specific account

### DIFF
--- a/contracts/LiquidityMining.sol
+++ b/contracts/LiquidityMining.sol
@@ -261,7 +261,7 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
     {
         totalStakers = totalStakers.sub(1);
 
-        (usdcOut, usdtOut, daiOut, reward) = _applyReward();
+        (usdcOut, usdtOut, daiOut, reward) = _applyReward(msg.sender);
 
         usdcOut = denormalize(usdc, usdcOut);
         usdtOut = denormalize(usdt, usdtOut);
@@ -303,7 +303,7 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
             uint256 usdtOut,
             uint256 daiOut,
             uint256 _reward
-        ) = _applyReward();
+        ) = _applyReward(msg.sender);
 
         reward = _reward;
 
@@ -335,7 +335,7 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
                 uint256 usdtOut,
                 uint256 daiOut,
                 uint256 reward
-            ) = _applyReward();
+            ) = _applyReward(msg.sender);
 
             addBackUsdc = usdcOut;
             addBackUsdt = usdtOut;
@@ -371,7 +371,7 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
         }
     }
 
-    function _applyReward()
+    function _applyReward(address account)
         private
         returns (
             uint256 usdcOut,
@@ -380,30 +380,30 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
             uint256 reward
         )
     {
-        uint256 _totalUserStake = totalUserStake(msg.sender);
+        uint256 _totalUserStake = totalUserStake(account);
         require(
             _totalUserStake > 0,
             "LiquidityMining::_applyReward: no stablecoins staked"
         );
 
-        usdcOut = _userStakedUsdc[msg.sender];
-        usdtOut = _userStakedUsdt[msg.sender];
-        daiOut = _userStakedDai[msg.sender];
+        usdcOut = _userStakedUsdc[account];
+        usdtOut = _userStakedUsdt[account];
+        daiOut = _userStakedDai[account];
 
         reward = _totalUserStake
-            .mul(_totalWeight.sub(_userWeighted[msg.sender]))
+            .mul(_totalWeight.sub(_userWeighted[account]))
             .div(10**18)
-            .add(_userAccumulated[msg.sender]);
+            .add(_userAccumulated[account]);
 
         _totalStakeUsdc = _totalStakeUsdc.sub(usdcOut);
         _totalStakeUsdt = _totalStakeUsdt.sub(usdtOut);
         _totalStakeDai = _totalStakeDai.sub(daiOut);
 
-        _userStakedUsdc[msg.sender] = 0;
-        _userStakedUsdt[msg.sender] = 0;
-        _userStakedDai[msg.sender] = 0;
+        _userStakedUsdc[account] = 0;
+        _userStakedUsdt[account] = 0;
+        _userStakedDai[account] = 0;
 
-        _userAccumulated[msg.sender] = 0;
+        _userAccumulated[account] = 0;
     }
 
     function rescueTokens(

--- a/contracts/LiquidityMining.sol
+++ b/contracts/LiquidityMining.sol
@@ -44,12 +44,13 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
         uint256 usdtIn,
         uint256 daiIn
     );
-    event Payout(address indexed staker, uint256 reward);
+    event Payout(address indexed staker, uint256 reward, address to);
     event Withdraw(
         address indexed staker,
         uint256 usdcOut,
         uint256 usdtOut,
-        uint256 daiOut
+        uint256 daiOut,
+        address to
     );
 
     constructor(
@@ -247,7 +248,7 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
         emit Stake(msg.sender, usdcIn, usdtIn, daiIn);
     }
 
-    function withdraw()
+    function withdraw(address to)
         public
         update
         nonReentrant
@@ -267,31 +268,36 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
         daiOut = denormalize(dai, daiOut);
 
         if (usdcOut > 0) {
-            usdc.transfer(msg.sender, usdcOut);
+            usdc.transfer(to, usdcOut);
         }
 
         if (usdtOut > 0) {
-            usdt.transfer(msg.sender, usdtOut);
+            usdt.transfer(to, usdtOut);
         }
 
         if (daiOut > 0) {
-            dai.transfer(msg.sender, daiOut);
+            dai.transfer(to, daiOut);
         }
 
         if (reward > 0) {
-            sarco.transfer(msg.sender, reward);
+            sarco.transfer(to, reward);
             userClaimedRewards[msg.sender] = userClaimedRewards[msg.sender].add(
                 reward
             );
             totalClaimedRewards = totalClaimedRewards.add(reward);
 
-            emit Payout(msg.sender, reward);
+            emit Payout(msg.sender, reward, to);
         }
 
-        emit Withdraw(msg.sender, usdcOut, usdtOut, daiOut);
+        emit Withdraw(msg.sender, usdcOut, usdtOut, daiOut, to);
     }
 
-    function payout() public update nonReentrant returns (uint256 reward) {
+    function payout(address to)
+        public
+        update
+        nonReentrant
+        returns (uint256 reward)
+    {
         (
             uint256 usdcOut,
             uint256 usdtOut,
@@ -302,7 +308,7 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
         reward = _reward;
 
         if (reward > 0) {
-            sarco.transfer(msg.sender, reward);
+            sarco.transfer(to, reward);
             userClaimedRewards[msg.sender] = userClaimedRewards[msg.sender].add(
                 reward
             );
@@ -311,7 +317,7 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
 
         _stake(usdcOut, usdtOut, daiOut);
 
-        emit Payout(msg.sender, _reward);
+        emit Payout(msg.sender, _reward, to);
     }
 
     function _stake(

--- a/contracts/LiquidityMining.sol
+++ b/contracts/LiquidityMining.sol
@@ -242,7 +242,8 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
         _stake(
             normalize(usdc, usdcIn),
             normalize(usdt, usdtIn),
-            normalize(dai, daiIn)
+            normalize(dai, daiIn),
+            msg.sender
         );
 
         emit Stake(msg.sender, usdcIn, usdtIn, daiIn);
@@ -315,7 +316,7 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
             totalClaimedRewards = totalClaimedRewards.add(reward);
         }
 
-        _stake(usdcOut, usdtOut, daiOut);
+        _stake(usdcOut, usdtOut, daiOut, msg.sender);
 
         emit Payout(msg.sender, _reward, to);
     }
@@ -323,36 +324,37 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
     function _stake(
         uint256 usdcIn,
         uint256 usdtIn,
-        uint256 daiIn
+        uint256 daiIn,
+        address account
     ) private {
         uint256 addBackUsdc;
         uint256 addBackUsdt;
         uint256 addBackDai;
 
-        if (totalUserStake(msg.sender) > 0) {
+        if (totalUserStake(account) > 0) {
             (
                 uint256 usdcOut,
                 uint256 usdtOut,
                 uint256 daiOut,
                 uint256 reward
-            ) = _applyReward(msg.sender);
+            ) = _applyReward(account);
 
             addBackUsdc = usdcOut;
             addBackUsdt = usdtOut;
             addBackDai = daiOut;
 
-            _userStakedUsdc[msg.sender] = usdcOut;
-            _userStakedUsdt[msg.sender] = usdtOut;
-            _userStakedDai[msg.sender] = daiOut;
+            _userStakedUsdc[account] = usdcOut;
+            _userStakedUsdt[account] = usdtOut;
+            _userStakedDai[account] = daiOut;
 
-            _userAccumulated[msg.sender] = reward;
+            _userAccumulated[account] = reward;
         }
 
-        _userStakedUsdc[msg.sender] = _userStakedUsdc[msg.sender].add(usdcIn);
-        _userStakedUsdt[msg.sender] = _userStakedUsdt[msg.sender].add(usdtIn);
-        _userStakedDai[msg.sender] = _userStakedDai[msg.sender].add(daiIn);
+        _userStakedUsdc[account] = _userStakedUsdc[account].add(usdcIn);
+        _userStakedUsdt[account] = _userStakedUsdt[account].add(usdtIn);
+        _userStakedDai[account] = _userStakedDai[account].add(daiIn);
 
-        _userWeighted[msg.sender] = _totalWeight;
+        _userWeighted[account] = _totalWeight;
 
         _totalStakeUsdc = _totalStakeUsdc.add(usdcIn);
         _totalStakeUsdt = _totalStakeUsdt.add(usdtIn);

--- a/src/components/PayoutWithdraw.js
+++ b/src/components/PayoutWithdraw.js
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react'
 import { useData } from '../dataContext'
 import { useTransaction } from '../dataContext/transactions'
+import { useWeb3 } from '../web3'
 
 const PayoutWithdraw = () => {
+  const { account } = useWeb3()
   const {
     liquidityMining,
     canPayout,
@@ -31,14 +33,14 @@ const PayoutWithdraw = () => {
 
   const payout = () => {
     contractCall(
-      liquidityMining.payout, [{ gasLimit: 200000 }],
+      liquidityMining.payout, [account, { gasLimit: 200000 }],
       "Paying out rewards...", "Payout failed!", "Payout successful!"
     )
   }
 
   const withdraw = () => {
     contractCall(
-      liquidityMining.withdraw, [{ gasLimit: 300000 }],
+      liquidityMining.withdraw, [account, { gasLimit: 300000 }],
       "Withdrawing stake...", "Withdraw failed!", "Withdraw successful!"
     )
   }

--- a/src/dataContext/myRewards.js
+++ b/src/dataContext/myRewards.js
@@ -17,7 +17,7 @@ const useMyPendingRewards = (liquidityMining, currentBlock, currentTime, rewardI
 
     liquidityMining.totalUserStake(account).then(stake => {
       if (stake.gt(0)) {
-        liquidityMining.callStatic.payout().then(reward => {
+        liquidityMining.callStatic.payout(account).then(reward => {
           setPendingRewards(reward)
         }).catch(console.error)
       } else {

--- a/src/dataContext/myRewards.js
+++ b/src/dataContext/myRewards.js
@@ -45,7 +45,7 @@ const useMyClaimedRewards = (liquidityMining) => {
       setClaimedRewards(rewards => rewards.add(reward))
     }
 
-    const myClaimedRewardsFilter = liquidityMining.filters.Payout(account, null)
+    const myClaimedRewardsFilter = liquidityMining.filters.Payout(account, null, null)
     liquidityMining.on(myClaimedRewardsFilter, addMyClaimedRewards)
 
     return () => {

--- a/src/dataContext/myStakes.js
+++ b/src/dataContext/myStakes.js
@@ -24,7 +24,7 @@ const useMyStakeUsdc = (liquidityMining) => {
     const myStakeFilter = liquidityMining.filters.Stake(account, null, null, null)
     liquidityMining.on(myStakeFilter, addUsdc)
 
-    const myWithdrawFilter = liquidityMining.filters.Withdraw(account, null, null, null)
+    const myWithdrawFilter = liquidityMining.filters.Withdraw(account, null, null, null, null)
     liquidityMining.on(myWithdrawFilter, removeUsdc)
 
     return () => {
@@ -58,7 +58,7 @@ const useMyStakeUsdt = (liquidityMining) => {
     const myStakeFilter = liquidityMining.filters.Stake(account, null, null, null)
     liquidityMining.on(myStakeFilter, addUsdt)
 
-    const myWithdrawFilter = liquidityMining.filters.Withdraw(account, null, null, null)
+    const myWithdrawFilter = liquidityMining.filters.Withdraw(account, null, null, null, null)
     liquidityMining.on(myWithdrawFilter, removeUsdt)
 
     return () => {
@@ -92,7 +92,7 @@ const useMyStakeDai = (liquidityMining) => {
     const myStakeFilter = liquidityMining.filters.Stake(account, null, null, null)
     liquidityMining.on(myStakeFilter, addDai)
 
-    const myWithdrawFilter = liquidityMining.filters.Withdraw(account, null, null, null)
+    const myWithdrawFilter = liquidityMining.filters.Withdraw(account, null, null, null, null)
     liquidityMining.on(myWithdrawFilter, removeDai)
 
     return () => {

--- a/src/web3/fallback.js
+++ b/src/web3/fallback.js
@@ -7,7 +7,7 @@ const useFallbackConnect = (next) => {
   useEffect(() => {
     if (provider || !next) return
 
-    setProvider(getDefaultProvider(parseInt(process.env.REACT_APP_DEFAULT_CHAIN_ID, 10)))      
+    setProvider(getDefaultProvider(parseInt(process.env.REACT_APP_DEFAULT_CHAIN_ID, 10)))
   }, [provider, next])
 
   return provider

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -17,10 +17,10 @@ module.exports = {
     solc: {
       version: '0.6.12',
       settings: {
-       optimizer: {
-         enabled: true,
-         runs: 1000
-       }
+        optimizer: {
+          enabled: true,
+          runs: 1000
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #1 

### Commit `7bccaf3`
Fixes the referenced issue, in the smart contract

### Commits `d81be2d` and `9f0cbda`
Some general refactoring, in which references to `msg.sender` are fully contained within `public` functions

### Commit `9c69c69`
Some unrelated whitespace cleanup in other files

### Commit `3de6600`
Fix the frontend to include the user's address as inputs to `payout` and `withdraw`

### Commit `123045c`
Update the event listeners on the frontend to account for the new parameter in `Payout` and `Withdraw` events