### PR TITLE
Fix transferFrom

### DIFF
--- a/contracts/LiquidityMining2.sol
+++ b/contracts/LiquidityMining2.sol
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.12;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+contract LiquidityMining is Ownable, ReentrancyGuard {
+    using SafeMath for uint256;
+    using SafeMath for uint8;
+
+    ERC20 public immutable usdc;
+    ERC20 public immutable usdt;
+    ERC20 public immutable dai;
+    ERC20 public immutable sarco;
+
+    uint256 public totalStakers;
+    uint256 public totalRewards;
+    uint256 public totalClaimedRewards;
+    uint256 public startTime;
+    uint256 public firstStakeTime;
+    uint256 public endTime;
+
+    uint256 private _totalStakeUsdc;
+    uint256 private _totalStakeUsdt;
+    uint256 private _totalStakeDai;
+    uint256 private _totalWeight;
+    uint256 private _mostRecentValueCalcTime;
+
+    mapping(address => uint256) public userClaimedRewards;
+
+    mapping(address => uint256) private _userStakedUsdc;
+    mapping(address => uint256) private _userStakedUsdt;
+    mapping(address => uint256) private _userStakedDai;
+    mapping(address => uint256) private _userWeighted;
+    mapping(address => uint256) private _userAccumulated;
+
+    event Deposit(uint256 totalRewards, uint256 startTime, uint256 endTime);
+    event Stake(
+        address indexed staker,
+        uint256 usdcIn,
+        uint256 usdtIn,
+        uint256 daiIn
+    );
+    event Payout(address indexed staker, uint256 reward, address to);
+    event Withdraw(
+        address indexed staker,
+        uint256 usdcOut,
+        uint256 usdtOut,
+        uint256 daiOut,
+        address to
+    );
+
+    constructor(
+        address _usdc,
+        address _usdt,
+        address _dai,
+        address _sarco,
+        address owner
+    ) public {
+        usdc = ERC20(_usdc);
+        usdt = ERC20(_usdt);
+        dai = ERC20(_dai);
+        sarco = ERC20(_sarco);
+
+        transferOwnership(owner);
+    }
+
+    function totalStakeUsdc() public view returns (uint256 totalUsdc) {
+        totalUsdc = denormalize(usdc, _totalStakeUsdc);
+    }
+
+    function totalStakeUsdt() public view returns (uint256 totalUsdt) {
+        totalUsdt = denormalize(usdt, _totalStakeUsdt);
+    }
+
+    function totalStakeDai() public view returns (uint256 totalDai) {
+        totalDai = denormalize(dai, _totalStakeDai);
+    }
+
+    function userStakeUsdc(address user)
+        public
+        view
+        returns (uint256 usdcStake)
+    {
+        usdcStake = denormalize(usdc, _userStakedUsdc[user]);
+    }
+
+    function userStakeUsdt(address user)
+        public
+        view
+        returns (uint256 usdtStake)
+    {
+        usdtStake = denormalize(usdt, _userStakedUsdt[user]);
+    }
+
+    function userStakeDai(address user) public view returns (uint256 daiStake) {
+        daiStake = denormalize(dai, _userStakedDai[user]);
+    }
+
+    function deposit(
+        uint256 _totalRewards,
+        uint256 _startTime,
+        uint256 _endTime
+    ) public onlyOwner {
+        require(
+            startTime == 0,
+            "LiquidityMining::deposit: already received deposit"
+        );
+
+        require(
+            _startTime >= block.timestamp,
+            "LiquidityMining::deposit: start time must be in future"
+        );
+
+        require(
+            _endTime > _startTime,
+            "LiquidityMining::deposit: end time must after start time"
+        );
+
+        require(
+            sarco.balanceOf(address(this)) == _totalRewards,
+            "LiquidityMining::deposit: contract balance does not equal expected _totalRewards"
+        );
+
+        totalRewards = _totalRewards;
+        startTime = _startTime;
+        endTime = _endTime;
+
+        emit Deposit(_totalRewards, _startTime, _endTime);
+    }
+
+    function totalStake() public view returns (uint256 total) {
+        total = _totalStakeUsdc.add(_totalStakeUsdt).add(_totalStakeDai);
+    }
+
+    function totalUserStake(address user) public view returns (uint256 total) {
+        total = _userStakedUsdc[user].add(_userStakedUsdt[user]).add(
+            _userStakedDai[user]
+        );
+    }
+
+    modifier update() {
+        if (_mostRecentValueCalcTime == 0) {
+            _mostRecentValueCalcTime = firstStakeTime;
+        }
+
+        uint256 totalCurrentStake = totalStake();
+
+        if (totalCurrentStake > 0 && _mostRecentValueCalcTime < endTime) {
+            uint256 value = 0;
+            uint256 sinceLastCalc = block.timestamp.sub(
+                _mostRecentValueCalcTime
+            );
+            uint256 perSecondReward = totalRewards.div(
+                endTime.sub(firstStakeTime)
+            );
+
+            if (block.timestamp < endTime) {
+                value = sinceLastCalc.mul(perSecondReward);
+            } else {
+                uint256 sinceEndTime = block.timestamp.sub(endTime);
+                value = (sinceLastCalc.sub(sinceEndTime)).mul(perSecondReward);
+            }
+
+            _totalWeight = _totalWeight.add(
+                value.mul(10**18).div(totalCurrentStake)
+            );
+
+            _mostRecentValueCalcTime = block.timestamp;
+        }
+
+        _;
+    }
+
+    function shift(ERC20 token) private view returns (uint8 shifted) {
+        uint8 decimals = token.decimals();
+        shifted = uint8(uint8(18).sub(decimals));
+    }
+
+    function normalize(ERC20 token, uint256 tokenIn)
+        private
+        view
+        returns (uint256 normalized)
+    {
+        uint8 _shift = shift(token);
+        normalized = tokenIn.mul(10**uint256(_shift));
+    }
+
+    function denormalize(ERC20 token, uint256 tokenIn)
+        private
+        view
+        returns (uint256 denormalized)
+    {
+        uint8 _shift = shift(token);
+        denormalized = tokenIn.div(10**uint256(_shift));
+    }
+
+    function stake(
+        uint256 usdcIn,
+        uint256 usdtIn,
+        uint256 daiIn
+    ) public update nonReentrant {
+        require(
+            usdcIn > 0 || usdtIn > 0 || daiIn > 0,
+            "LiquidityMining::stake: missing stablecoin"
+        );
+        require(
+            block.timestamp >= startTime,
+            "LiquidityMining::stake: staking isn't live yet"
+        );
+        require(
+            sarco.balanceOf(address(this)) > 0,
+            "LiquidityMining::stake: no sarco balance"
+        );
+
+        if (firstStakeTime == 0) {
+            firstStakeTime = block.timestamp;
+        } else {
+            require(
+                block.timestamp < endTime,
+                "LiquidityMining::stake: staking is over"
+            );
+        }
+
+        if (usdcIn > 0) {
+            usdc.transferFrom(msg.sender, address(this), usdcIn);
+        }
+
+        if (usdtIn > 0) {
+            usdt.transferFrom(msg.sender, address(this), usdtIn);
+        }
+
+        if (daiIn > 0) {
+            dai.transferFrom(msg.sender, address(this), daiIn);
+        }
+
+        if (totalUserStake(msg.sender) == 0) {
+            totalStakers = totalStakers.add(1);
+        }
+
+        _stake(
+            normalize(usdc, usdcIn),
+            normalize(usdt, usdtIn),
+            normalize(dai, daiIn),
+            msg.sender
+        );
+
+        emit Stake(msg.sender, usdcIn, usdtIn, daiIn);
+    }
+
+    function withdraw(address to)
+        public
+        update
+        nonReentrant
+        returns (
+            uint256 usdcOut,
+            uint256 usdtOut,
+            uint256 daiOut,
+            uint256 reward
+        )
+    {
+        totalStakers = totalStakers.sub(1);
+
+        (usdcOut, usdtOut, daiOut, reward) = _applyReward(msg.sender);
+
+        usdcOut = denormalize(usdc, usdcOut);
+        usdtOut = denormalize(usdt, usdtOut);
+        daiOut = denormalize(dai, daiOut);
+
+        if (usdcOut > 0) {
+            usdc.transfer(to, usdcOut);
+        }
+
+        if (usdtOut > 0) {
+            usdt.transfer(to, usdtOut);
+        }
+
+        if (daiOut > 0) {
+            dai.transfer(to, daiOut);
+        }
+
+        if (reward > 0) {
+            sarco.transfer(to, reward);
+            userClaimedRewards[msg.sender] = userClaimedRewards[msg.sender].add(
+                reward
+            );
+            totalClaimedRewards = totalClaimedRewards.add(reward);
+
+            emit Payout(msg.sender, reward, to);
+        }
+
+        emit Withdraw(msg.sender, usdcOut, usdtOut, daiOut, to);
+    }
+
+    function payout(address to)
+        public
+        update
+        nonReentrant
+        returns (uint256 reward)
+    {
+        (
+            uint256 usdcOut,
+            uint256 usdtOut,
+            uint256 daiOut,
+            uint256 _reward
+        ) = _applyReward(msg.sender);
+
+        reward = _reward;
+
+        if (reward > 0) {
+            sarco.transfer(to, reward);
+            userClaimedRewards[msg.sender] = userClaimedRewards[msg.sender].add(
+                reward
+            );
+            totalClaimedRewards = totalClaimedRewards.add(reward);
+        }
+
+        _stake(usdcOut, usdtOut, daiOut, msg.sender);
+
+        emit Payout(msg.sender, _reward, to);
+    }
+
+    function _stake(
+        uint256 usdcIn,
+        uint256 usdtIn,
+        uint256 daiIn,
+        address account
+    ) private {
+        uint256 addBackUsdc;
+        uint256 addBackUsdt;
+        uint256 addBackDai;
+
+        if (totalUserStake(account) > 0) {
+            (
+                uint256 usdcOut,
+                uint256 usdtOut,
+                uint256 daiOut,
+                uint256 reward
+            ) = _applyReward(account);
+
+            addBackUsdc = usdcOut;
+            addBackUsdt = usdtOut;
+            addBackDai = daiOut;
+
+            _userStakedUsdc[account] = usdcOut;
+            _userStakedUsdt[account] = usdtOut;
+            _userStakedDai[account] = daiOut;
+
+            _userAccumulated[account] = reward;
+        }
+
+        _userStakedUsdc[account] = _userStakedUsdc[account].add(usdcIn);
+        _userStakedUsdt[account] = _userStakedUsdt[account].add(usdtIn);
+        _userStakedDai[account] = _userStakedDai[account].add(daiIn);
+
+        _userWeighted[account] = _totalWeight;
+
+        _totalStakeUsdc = _totalStakeUsdc.add(usdcIn);
+        _totalStakeUsdt = _totalStakeUsdt.add(usdtIn);
+        _totalStakeDai = _totalStakeDai.add(daiIn);
+
+        if (addBackUsdc > 0) {
+            _totalStakeUsdc = _totalStakeUsdc.add(addBackUsdc);
+        }
+
+        if (addBackUsdt > 0) {
+            _totalStakeUsdt = _totalStakeUsdt.add(addBackUsdt);
+        }
+
+        if (addBackDai > 0) {
+            _totalStakeDai = _totalStakeDai.add(addBackDai);
+        }
+    }
+
+    function _applyReward(address account)
+        private
+        returns (
+            uint256 usdcOut,
+            uint256 usdtOut,
+            uint256 daiOut,
+            uint256 reward
+        )
+    {
+        uint256 _totalUserStake = totalUserStake(account);
+        require(
+            _totalUserStake > 0,
+            "LiquidityMining::_applyReward: no stablecoins staked"
+        );
+
+        usdcOut = _userStakedUsdc[account];
+        usdtOut = _userStakedUsdt[account];
+        daiOut = _userStakedDai[account];
+
+        reward = _totalUserStake
+            .mul(_totalWeight.sub(_userWeighted[account]))
+            .div(10**18)
+            .add(_userAccumulated[account]);
+
+        _totalStakeUsdc = _totalStakeUsdc.sub(usdcOut);
+        _totalStakeUsdt = _totalStakeUsdt.sub(usdtOut);
+        _totalStakeDai = _totalStakeDai.sub(daiOut);
+
+        _userStakedUsdc[account] = 0;
+        _userStakedUsdt[account] = 0;
+        _userStakedDai[account] = 0;
+
+        _userAccumulated[account] = 0;
+    }
+
+    function rescueTokens(
+        address tokenToRescue,
+        address to,
+        uint256 amount
+    ) public onlyOwner nonReentrant returns (bool) {
+        if (tokenToRescue == address(usdc)) {
+            require(
+                amount <= usdc.balanceOf(address(this)).sub(_totalStakeUsdc),
+                "LiquidityMining::rescueTokens: that usdc belongs to stakers"
+            );
+        } else if (tokenToRescue == address(usdt)) {
+            require(
+                amount <= usdt.balanceOf(address(this)).sub(_totalStakeUsdt),
+                "LiquidityMining::rescueTokens: that usdt belongs to stakers"
+            );
+        } else if (tokenToRescue == address(dai)) {
+            require(
+                amount <= dai.balanceOf(address(this)).sub(_totalStakeDai),
+                "LiquidityMining::rescueTokens: that dai belongs to stakers"
+            );
+        } else if (tokenToRescue == address(sarco)) {
+            if (totalStakers > 0) {
+                require(
+                    amount <=
+                        sarco.balanceOf(address(this)).sub(
+                            totalRewards.sub(totalClaimedRewards)
+                        ),
+                    "LiquidityMining::rescueTokens: that sarco belongs to stakers"
+                );
+            }
+        }
+
+        return IERC20(tokenToRescue).transfer(to, amount);
+    }
+}

--- a/contracts/LiquidityMining2.sol
+++ b/contracts/LiquidityMining2.sol
@@ -5,11 +5,13 @@ pragma solidity ^0.6.12;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract LiquidityMining is Ownable, ReentrancyGuard {
+contract LiquidityMining2 is Ownable, ReentrancyGuard {
     using SafeMath for uint256;
     using SafeMath for uint8;
+    using SafeERC20 for ERC20;
 
     ERC20 public immutable usdc;
     ERC20 public immutable usdt;
@@ -226,15 +228,15 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
         }
 
         if (usdcIn > 0) {
-            usdc.transferFrom(msg.sender, address(this), usdcIn);
+            usdc.safeTransferFrom(msg.sender, address(this), usdcIn);
         }
 
         if (usdtIn > 0) {
-            usdt.transferFrom(msg.sender, address(this), usdtIn);
+            usdt.safeTransferFrom(msg.sender, address(this), usdtIn);
         }
 
         if (daiIn > 0) {
-            dai.transferFrom(msg.sender, address(this), daiIn);
+            dai.safeTransferFrom(msg.sender, address(this), daiIn);
         }
 
         if (totalUserStake(msg.sender) == 0) {
@@ -271,19 +273,19 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
         daiOut = denormalize(dai, daiOut);
 
         if (usdcOut > 0) {
-            usdc.transfer(to, usdcOut);
+            usdc.safeTransfer(to, usdcOut);
         }
 
         if (usdtOut > 0) {
-            usdt.transfer(to, usdtOut);
+            usdt.safeTransfer(to, usdtOut);
         }
 
         if (daiOut > 0) {
-            dai.transfer(to, daiOut);
+            dai.safeTransfer(to, daiOut);
         }
 
         if (reward > 0) {
-            sarco.transfer(to, reward);
+            sarco.safeTransfer(to, reward);
             userClaimedRewards[msg.sender] = userClaimedRewards[msg.sender].add(
                 reward
             );
@@ -311,7 +313,7 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
         reward = _reward;
 
         if (reward > 0) {
-            sarco.transfer(to, reward);
+            sarco.safeTransfer(to, reward);
             userClaimedRewards[msg.sender] = userClaimedRewards[msg.sender].add(
                 reward
             );
@@ -414,7 +416,7 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
         address tokenToRescue,
         address to,
         uint256 amount
-    ) public onlyOwner nonReentrant returns (bool) {
+    ) public onlyOwner nonReentrant {
         if (tokenToRescue == address(usdc)) {
             require(
                 amount <= usdc.balanceOf(address(this)).sub(_totalStakeUsdc),
@@ -442,6 +444,6 @@ contract LiquidityMining is Ownable, ReentrancyGuard {
             }
         }
 
-        return IERC20(tokenToRescue).transfer(to, amount);
+        ERC20(tokenToRescue).safeTransfer(to, amount);
     }
 }

--- a/migrations/4_liquidity_mining_2.js
+++ b/migrations/4_liquidity_mining_2.js
@@ -1,0 +1,61 @@
+/* global artifacts */
+
+const LiquidityMining2 = artifacts.require('LiquidityMining2')
+const UsdcMock = artifacts.require('UsdcMock')
+const UsdtMock = artifacts.require('UsdtMock')
+const DaiMock = artifacts.require('DaiMock')
+const SarcoMock = artifacts.require('SarcoMock')
+
+module.exports = async function (deployer, network, accounts) {
+  let usdcAddress, usdtAddress, daiAddress, sarcoAddress, ownerAddress
+
+  if (['mainnet', 'mainnet-fork'].includes(network)) {
+    usdcAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+    usdtAddress = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+    daiAddress = '0x6b175474e89094c44da98b954eedeac495271d0f'
+    sarcoAddress = '0x7697b462a7c4ff5f8b55bdbc2f4076c2af9cf51a'
+    
+    // yikes, what is this all about
+    // c'mon truffle
+    if (network === 'mainnet-fork') {
+      ownerAddress = deployer.provider.options.unlocked_accounts[0]
+    } else if (network === 'mainnet') {
+      ownerAddress = accounts[0]
+    } else {
+      console.error('which network are we on?', network)
+      process.exit(1)
+    }
+  } else if (['goerli', 'goerli-fork'].includes(network)) {
+    await deployer.deploy(SarcoMock)
+    sarcoAddress = (await SarcoMock.deployed()).address
+
+    usdcAddress = '0x92321c730f047bb289c2b37e5a5fdd891e660f0b'
+    usdtAddress = '0x479051fecbf65b3a1ecab1d01f200c88fc83cc41'
+    daiAddress = '0xb174bfb76d9b5b3b394d33057fd08f84151047b4'
+
+    // yikes, what is this all about
+    // c'mon truffle
+    if (network === 'goerli-fork') {
+      ownerAddress = deployer.provider.options.unlocked_accounts[0]
+    } else if (network === 'goerli') {
+      ownerAddress = accounts[0]
+    } else {
+      console.error('which network are we on?', network)
+      process.exit(1)
+    }
+  } else {
+    await deployer.deploy(UsdcMock)
+    await deployer.deploy(UsdtMock)
+    await deployer.deploy(DaiMock)
+    await deployer.deploy(SarcoMock)
+
+    usdcAddress = (await UsdcMock.deployed()).address
+    usdtAddress = (await UsdtMock.deployed()).address
+    daiAddress = (await DaiMock.deployed()).address
+    sarcoAddress = (await SarcoMock.deployed()).address
+
+    ownerAddress = accounts[0]
+  }
+
+  await deployer.deploy(LiquidityMining2, usdcAddress, usdtAddress, daiAddress, sarcoAddress, ownerAddress)
+}

--- a/migrations/5_deposit_reward_2.js
+++ b/migrations/5_deposit_reward_2.js
@@ -1,0 +1,39 @@
+/* global artifacts web3 */
+
+const LiquidityMining2 = artifacts.require('LiquidityMining2')
+const SarcoMock = artifacts.require('SarcoMock')
+const BN = web3.utils.BN
+
+module.exports = async function (_, network) {
+  if (['develop', 'test'].includes(network)) {
+    const liquidityMining2 = await LiquidityMining2.deployed()
+    const amount = (new BN(1000000)).mul(new BN(10).pow(new BN(18)))
+
+    const sarcoMock = await SarcoMock.deployed()
+    await sarcoMock.transfer(liquidityMining2.address, amount)
+
+    const currentTime = (await web3.eth.getBlock('latest')).timestamp
+    const startTime = currentTime + 60 * 1
+    const endTime = currentTime + 60 * 120
+    await liquidityMining2.deposit(amount, startTime, endTime)
+  } else if (['goerli', 'goerli-fork'].includes(network)) {
+    const liquidityMining = await LiquidityMining2.deployed()
+    const amount = (new BN(1000000)).mul(new BN(10).pow(new BN(18)))
+
+    const sarcoMock = await SarcoMock.deployed()
+    await sarcoMock.transfer(liquidityMining.address, amount)
+
+    const startTime = 1609786800
+    const endTime = 1609873200
+    await liquidityMining.deposit(amount, startTime, endTime)
+  } else if (['mainnet', 'mainnet-fork'].includes(network)) {
+    const liquidityMining2 = await LiquidityMining2.deployed()
+    const amount = (new BN(1000000)).mul(new BN(10).pow(new BN(18)))
+
+    // tokens will be sent to the Liquidity Mining contract, outside of this migration
+
+    const startTime = 1610582400 // Jan 14 2021 00:00:00 GMT
+    const endTime = startTime + (60 * 60 * 24 * 365) // 1 year
+    await liquidityMining2.deposit(amount, startTime, endTime)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2307,6 +2307,44 @@
         }
       }
     },
+    "@openzeppelin/contract-loader": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contract-loader/-/contract-loader-0.6.2.tgz",
+      "integrity": "sha512-/P8v8ZFVwK+Z7rHQH2N3hqzEmTzLFjhMtvNK4FeIak6DEeONZ92vdFaFb10CCCQtp390Rp/Y57Rtfrm50bUdMQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
+      }
+    },
     "@openzeppelin/contracts": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.3.0.tgz",
@@ -2703,6 +2741,608 @@
         "tippy.js": "^6.2.0"
       }
     },
+    "@truffle/blockchain-utils": {
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.25.tgz",
+      "integrity": "sha512-XA5m0BfAWtysy5ChHyiAf1fXbJxJXphKk+eZ9Rb9Twi6fn3Jg4gnHNwYXJacYFEydqT5vr2s4Ou812JHlautpw==",
+      "dev": true,
+      "requires": {
+        "source-map-support": "^0.5.19"
+      }
+    },
+    "@truffle/codec": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.9.4.tgz",
+      "integrity": "sha512-EAx/6Dg8Dj/O6/zqXpp4Q9OtxKmPKItmHWD91FM7bOXvX71wx66XZqIxD7ORjLEzQqYfJj81ttSnOZgpGxj3RA==",
+      "dev": true,
+      "requires": {
+        "big.js": "^5.2.2",
+        "bn.js": "^4.11.8",
+        "cbor": "^5.1.0",
+        "debug": "^4.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.partition": "^4.6.0",
+        "lodash.sum": "^4.0.2",
+        "semver": "^6.3.0",
+        "source-map-support": "^0.5.19",
+        "utf8": "^3.0.0",
+        "web3-utils": "1.2.9"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "web3-utils": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
+          "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "@truffle/contract": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.3.5.tgz",
+      "integrity": "sha512-08gLSId+spnXqdM/25pOiurNcSBeCBa6KrplCgojy1RvqlG8JbEa9jXHWt1DCACZTtSnCsC2ywSNxAKRb4HqIA==",
+      "dev": true,
+      "requires": {
+        "@truffle/blockchain-utils": "^0.0.25",
+        "@truffle/contract-schema": "^3.3.3",
+        "@truffle/debug-utils": "^5.0.8",
+        "@truffle/error": "^0.0.11",
+        "@truffle/interface-adapter": "^0.4.18",
+        "bignumber.js": "^7.2.1",
+        "ethereum-ens": "^0.8.0",
+        "ethers": "^4.0.0-beta.1",
+        "source-map-support": "^0.5.19",
+        "web3": "1.2.9",
+        "web3-core-helpers": "1.2.9",
+        "web3-core-promievent": "1.2.9",
+        "web3-eth-abi": "1.2.9",
+        "web3-utils": "1.2.9"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.0.0-beta.153",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
+          "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": ">=5.0.0-beta.128",
+            "@ethersproject/bignumber": ">=5.0.0-beta.130",
+            "@ethersproject/bytes": ">=5.0.0-beta.129",
+            "@ethersproject/constants": ">=5.0.0-beta.128",
+            "@ethersproject/hash": ">=5.0.0-beta.128",
+            "@ethersproject/keccak256": ">=5.0.0-beta.127",
+            "@ethersproject/logger": ">=5.0.0-beta.129",
+            "@ethersproject/properties": ">=5.0.0-beta.131",
+            "@ethersproject/strings": ">=5.0.0-beta.130"
+          }
+        },
+        "@types/node": {
+          "version": "10.17.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.50.tgz",
+          "integrity": "sha512-vwX+/ija9xKc/z9VqMCdbf4WYcMTGsI0I/L/6shIF3qXURxZOhPQlPRHtjTpiNhAwn0paMJzlOQqw6mAGEQnTA==",
+          "dev": true
+        },
+        "bignumber.js": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "dev": true,
+          "requires": {
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
+          }
+        },
+        "ethers": {
+          "version": "4.0.48",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+          "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+          "dev": true,
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "oboe": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+          "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+          "dev": true,
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+          "dev": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
+        },
+        "web3": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.9.tgz",
+          "integrity": "sha512-Mo5aBRm0JrcNpN/g4VOrDzudymfOnHRC3s2VarhYxRA8aWgF5rnhQ0ziySaugpic1gksbXPe105pUWyRqw8HUA==",
+          "dev": true,
+          "requires": {
+            "web3-bzz": "1.2.9",
+            "web3-core": "1.2.9",
+            "web3-eth": "1.2.9",
+            "web3-eth-personal": "1.2.9",
+            "web3-net": "1.2.9",
+            "web3-shh": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.9.tgz",
+          "integrity": "sha512-ogVQr9jHodu9HobARtvUSmWG22cv2EUQzlPeejGWZ7j5h20HX40EDuWyomGY5VclIj5DdLY76Tmq88RTf/6nxA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^10.12.18",
+            "got": "9.6.0",
+            "swarm-js": "^0.1.40",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.9.tgz",
+          "integrity": "sha512-fSYv21IP658Ty2wAuU9iqmW7V+75DOYMVZsDH/c14jcF/1VXnedOcxzxSj3vArsCvXZNe6XC5/wAuGZyQwR9RA==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-requestmanager": "1.2.9",
+            "web3-utils": "1.2.9"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.19.13",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.13.tgz",
+              "integrity": "sha512-qdixo2f0U7z6m0UJUugTJqVF94GNDkdgQhfBtMs8t5898JE7G/D2kJYw4rc1nzjIPLVAsDkY2MdABnLAP5lM1w==",
+              "dev": true
+            },
+            "bignumber.js": {
+              "version": "9.0.1",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+              "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.9.tgz",
+          "integrity": "sha512-t0WAG3orLCE3lqi77ZoSRNFok3VQWZXTniZigDQjyOJYMAX7BU3F3js8HKbjVnAxlX3tiKoDxI0KBk9F3AxYuw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.9.tgz",
+          "integrity": "sha512-bjsIoqP3gs7A/gP8+QeLUCyOKJ8bopteCSNbCX36Pxk6TYfYWNuC6hP+2GzUuqdP3xaZNe+XEElQFUNpR3oyAg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-promievent": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.9.tgz",
+          "integrity": "sha512-0eAUA2zjgXTleSrnc1wdoKQPPIHU6KHf4fAscu4W9kKrR+mqP1KsjYrxY9wUyjNnXxfQ+5M29ipvbiaK8OqdOw==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.9.tgz",
+          "integrity": "sha512-1PwKV2m46ALUnIN5VPPgjOj8yMLJhhqZYvYJE34hTN5SErOkwhzx5zScvo5MN7v7KyQGFnpVCZKKGCiEnDmtFA==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9",
+            "web3-providers-http": "1.2.9",
+            "web3-providers-ipc": "1.2.9",
+            "web3-providers-ws": "1.2.9"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.9.tgz",
+          "integrity": "sha512-Y48TvXPSPxEM33OmXjGVDMzTd0j8X0t2+sDw66haeBS8eYnrEzasWuBZZXDq0zNUsqyxItgBGDn+cszkgEnFqg==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.9.tgz",
+          "integrity": "sha512-sIKO4iE9FEBa/CYUd6GdPd7GXt/wISqxUd8PlIld6+hvMJj02lgO7Z7p5T9mZIJcIZJGvZX81ogx8oJ9yif+Ag==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-eth-abi": "1.2.9",
+            "web3-eth-accounts": "1.2.9",
+            "web3-eth-contract": "1.2.9",
+            "web3-eth-ens": "1.2.9",
+            "web3-eth-iban": "1.2.9",
+            "web3-eth-personal": "1.2.9",
+            "web3-net": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.9.tgz",
+          "integrity": "sha512-3YwUYbh/DMfDbhMWEebAdjSd5bj3ZQieOjLzWFHU23CaLEqT34sUix1lba+hgUH/EN6A7bKAuKOhR3p0OvTn7Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.0.0-beta.153",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.9.tgz",
+          "integrity": "sha512-jkbDCZoA1qv53mFcRHCinoCsgg8WH+M0YUO1awxmqWXRmCRws1wW0TsuSQ14UThih5Dxolgl+e+aGWxG58LMwg==",
+          "dev": true,
+          "requires": {
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "^0.2.8",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "scrypt-js": "^3.0.1",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-utils": "1.2.9"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "scrypt-js": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+              "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+              "dev": true
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.9.tgz",
+          "integrity": "sha512-PYMvJf7EG/HyssUZa+pXrc8IB06K/YFfWYyW4R7ed3sab+9wWUys1TlWxBCBuiBXOokSAyM6H6P6/cKEx8FT8Q==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-promievent": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-eth-abi": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.9.tgz",
+          "integrity": "sha512-kG4+ZRgZ8I1WYyOBGI8QVRHfUSbbJjvJAGA1AF/NOW7JXQ+x7gBGeJw6taDWJhSshMoEKWcsgvsiuoG4870YxQ==",
+          "dev": true,
+          "requires": {
+            "content-hash": "^2.5.2",
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-promievent": "1.2.9",
+            "web3-eth-abi": "1.2.9",
+            "web3-eth-contract": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.9.tgz",
+          "integrity": "sha512-RtdVvJE0pyg9dHLy0GzDiqgnLnssSzfz/JYguhC1wsj9+Gnq1M6Diy3NixACWUAp6ty/zafyOaZnNQ+JuH9TjQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.9"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.9.tgz",
+          "integrity": "sha512-cFiNrktxZ1C/rIdJFzQTvFn3/0zcsR3a+Jf8Y3KxeQDHszQtosjLWptP7bsUmDwEh4hzh0Cy3KpOxlYBWB8bJQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-net": "1.2.9",
+            "web3-utils": "1.2.9"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.19.13",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.13.tgz",
+              "integrity": "sha512-qdixo2f0U7z6m0UJUugTJqVF94GNDkdgQhfBtMs8t5898JE7G/D2kJYw4rc1nzjIPLVAsDkY2MdABnLAP5lM1w==",
+              "dev": true
+            }
+          }
+        },
+        "web3-net": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.9.tgz",
+          "integrity": "sha512-d2mTn8jPlg+SI2hTj2b32Qan6DmtU9ap/IUlJTeQbZQSkTLf0u9suW8Vjwyr4poJYXTurdSshE7OZsPNn30/ZA==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.9.tgz",
+          "integrity": "sha512-F956tCIj60Ttr0UvEHWFIhx+be3He8msoPzyA44/kfzzYoMAsCFRn5cf0zQG6al0znE75g6HlWVSN6s3yAh51A==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.9",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.9.tgz",
+          "integrity": "sha512-NQ8QnBleoHA2qTJlqoWu7EJAD/FR5uimf7Ielzk4Z2z+m+6UAuJdJMSuQNj+Umhz9L/Ys6vpS1vHx9NizFl+aQ==",
+          "dev": true,
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.9.tgz",
+          "integrity": "sha512-6+UpvINeI//dglZoAKStUXqxDOXJy6Iitv2z3dbgInG4zb8tkYl/VBDL80UjUg3ZvzWG0g7EKY2nRPEpON2TFA==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "^4.0.0",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9",
+            "websocket": "^1.0.31"
+          },
+          "dependencies": {
+            "eventemitter3": {
+              "version": "4.0.7",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+              "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+              "dev": true
+            }
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.9.tgz",
+          "integrity": "sha512-PWa8b/EaxaMinFaxy6cV0i0EOi2M7a/ST+9k9nhyhCjVa2vzXuNoBNo2IUOmeZ0WP2UQB8ByJ2+p4htlJaDOjA==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-net": "1.2.9"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
+          "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "@truffle/contract-schema": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.3.3.tgz",
+      "integrity": "sha512-4bvcEoGycopJBPoCiqHP5Q72/1t/ixYS/pVHru+Rzvad641BgvoGrkd4YnyJ+E/MVb4ZLrndL7whmdGqV5B7SA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.0",
+        "crypto-js": "^3.1.9-1",
+        "debug": "^4.1.0"
+      }
+    },
+    "@truffle/debug-utils": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-5.0.8.tgz",
+      "integrity": "sha512-2YzZzhhbZnUr+zQSiqkjF9cwwUPBFyMuH2/iGvjR+9l3+gpOm9+psN658dCziLV0qwiME4Tor4pIW7FnOEDegQ==",
+      "dev": true,
+      "requires": {
+        "@truffle/codec": "^0.9.4",
+        "@trufflesuite/chromafi": "^2.2.2",
+        "bn.js": "^5.1.3",
+        "chalk": "^2.4.2",
+        "debug": "^4.1.0",
+        "highlight.js": "^10.4.0",
+        "highlightjs-solidity": "^1.0.20"
+      }
+    },
+    "@truffle/error": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.11.tgz",
+      "integrity": "sha512-ju6TucjlJkfYMmdraYY/IBJaFb+Sa+huhYtOoyOJ+G29KcgytUVnDzKGwC7Kgk6IsxQMm62Mc1E0GZzFbGGipw==",
+      "dev": true
+    },
     "@truffle/hdwallet-provider": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.2.0.tgz",
@@ -2719,6 +3359,527 @@
         "ethereumjs-util": "^6.1.0",
         "ethereumjs-wallet": "^0.6.3",
         "source-map-support": "^0.5.19"
+      }
+    },
+    "@truffle/interface-adapter": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.4.18.tgz",
+      "integrity": "sha512-P9JVSYD/CX3V+NgTWu+Bf71sLh8pMwrCpbiYRB93pRw/1H3ZTvt5iDC2MVvVxCs8FkSiy4OZzQK/DJ8+hXAmYw==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.8",
+        "ethers": "^4.0.32",
+        "source-map-support": "^0.5.19",
+        "web3": "1.2.9"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.0.0-beta.153",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
+          "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": ">=5.0.0-beta.128",
+            "@ethersproject/bignumber": ">=5.0.0-beta.130",
+            "@ethersproject/bytes": ">=5.0.0-beta.129",
+            "@ethersproject/constants": ">=5.0.0-beta.128",
+            "@ethersproject/hash": ">=5.0.0-beta.128",
+            "@ethersproject/keccak256": ">=5.0.0-beta.127",
+            "@ethersproject/logger": ">=5.0.0-beta.129",
+            "@ethersproject/properties": ">=5.0.0-beta.131",
+            "@ethersproject/strings": ">=5.0.0-beta.130"
+          }
+        },
+        "@types/node": {
+          "version": "10.17.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.50.tgz",
+          "integrity": "sha512-vwX+/ija9xKc/z9VqMCdbf4WYcMTGsI0I/L/6shIF3qXURxZOhPQlPRHtjTpiNhAwn0paMJzlOQqw6mAGEQnTA==",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "dev": true,
+          "requires": {
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
+          }
+        },
+        "ethers": {
+          "version": "4.0.48",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+          "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+          "dev": true,
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "oboe": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+          "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+          "dev": true,
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+          "dev": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
+        },
+        "web3": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.9.tgz",
+          "integrity": "sha512-Mo5aBRm0JrcNpN/g4VOrDzudymfOnHRC3s2VarhYxRA8aWgF5rnhQ0ziySaugpic1gksbXPe105pUWyRqw8HUA==",
+          "dev": true,
+          "requires": {
+            "web3-bzz": "1.2.9",
+            "web3-core": "1.2.9",
+            "web3-eth": "1.2.9",
+            "web3-eth-personal": "1.2.9",
+            "web3-net": "1.2.9",
+            "web3-shh": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.9.tgz",
+          "integrity": "sha512-ogVQr9jHodu9HobARtvUSmWG22cv2EUQzlPeejGWZ7j5h20HX40EDuWyomGY5VclIj5DdLY76Tmq88RTf/6nxA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^10.12.18",
+            "got": "9.6.0",
+            "swarm-js": "^0.1.40",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.9.tgz",
+          "integrity": "sha512-fSYv21IP658Ty2wAuU9iqmW7V+75DOYMVZsDH/c14jcF/1VXnedOcxzxSj3vArsCvXZNe6XC5/wAuGZyQwR9RA==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-requestmanager": "1.2.9",
+            "web3-utils": "1.2.9"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.19.13",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.13.tgz",
+              "integrity": "sha512-qdixo2f0U7z6m0UJUugTJqVF94GNDkdgQhfBtMs8t5898JE7G/D2kJYw4rc1nzjIPLVAsDkY2MdABnLAP5lM1w==",
+              "dev": true
+            }
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.9.tgz",
+          "integrity": "sha512-t0WAG3orLCE3lqi77ZoSRNFok3VQWZXTniZigDQjyOJYMAX7BU3F3js8HKbjVnAxlX3tiKoDxI0KBk9F3AxYuw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.9.tgz",
+          "integrity": "sha512-bjsIoqP3gs7A/gP8+QeLUCyOKJ8bopteCSNbCX36Pxk6TYfYWNuC6hP+2GzUuqdP3xaZNe+XEElQFUNpR3oyAg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-promievent": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.9.tgz",
+          "integrity": "sha512-0eAUA2zjgXTleSrnc1wdoKQPPIHU6KHf4fAscu4W9kKrR+mqP1KsjYrxY9wUyjNnXxfQ+5M29ipvbiaK8OqdOw==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.9.tgz",
+          "integrity": "sha512-1PwKV2m46ALUnIN5VPPgjOj8yMLJhhqZYvYJE34hTN5SErOkwhzx5zScvo5MN7v7KyQGFnpVCZKKGCiEnDmtFA==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9",
+            "web3-providers-http": "1.2.9",
+            "web3-providers-ipc": "1.2.9",
+            "web3-providers-ws": "1.2.9"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.9.tgz",
+          "integrity": "sha512-Y48TvXPSPxEM33OmXjGVDMzTd0j8X0t2+sDw66haeBS8eYnrEzasWuBZZXDq0zNUsqyxItgBGDn+cszkgEnFqg==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.9.tgz",
+          "integrity": "sha512-sIKO4iE9FEBa/CYUd6GdPd7GXt/wISqxUd8PlIld6+hvMJj02lgO7Z7p5T9mZIJcIZJGvZX81ogx8oJ9yif+Ag==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-eth-abi": "1.2.9",
+            "web3-eth-accounts": "1.2.9",
+            "web3-eth-contract": "1.2.9",
+            "web3-eth-ens": "1.2.9",
+            "web3-eth-iban": "1.2.9",
+            "web3-eth-personal": "1.2.9",
+            "web3-net": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.9.tgz",
+          "integrity": "sha512-3YwUYbh/DMfDbhMWEebAdjSd5bj3ZQieOjLzWFHU23CaLEqT34sUix1lba+hgUH/EN6A7bKAuKOhR3p0OvTn7Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.0.0-beta.153",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.9.tgz",
+          "integrity": "sha512-jkbDCZoA1qv53mFcRHCinoCsgg8WH+M0YUO1awxmqWXRmCRws1wW0TsuSQ14UThih5Dxolgl+e+aGWxG58LMwg==",
+          "dev": true,
+          "requires": {
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "^0.2.8",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "scrypt-js": "^3.0.1",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-utils": "1.2.9"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "scrypt-js": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+              "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+              "dev": true
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.9.tgz",
+          "integrity": "sha512-PYMvJf7EG/HyssUZa+pXrc8IB06K/YFfWYyW4R7ed3sab+9wWUys1TlWxBCBuiBXOokSAyM6H6P6/cKEx8FT8Q==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-promievent": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-eth-abi": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.9.tgz",
+          "integrity": "sha512-kG4+ZRgZ8I1WYyOBGI8QVRHfUSbbJjvJAGA1AF/NOW7JXQ+x7gBGeJw6taDWJhSshMoEKWcsgvsiuoG4870YxQ==",
+          "dev": true,
+          "requires": {
+            "content-hash": "^2.5.2",
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-promievent": "1.2.9",
+            "web3-eth-abi": "1.2.9",
+            "web3-eth-contract": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.9.tgz",
+          "integrity": "sha512-RtdVvJE0pyg9dHLy0GzDiqgnLnssSzfz/JYguhC1wsj9+Gnq1M6Diy3NixACWUAp6ty/zafyOaZnNQ+JuH9TjQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.9"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.9.tgz",
+          "integrity": "sha512-cFiNrktxZ1C/rIdJFzQTvFn3/0zcsR3a+Jf8Y3KxeQDHszQtosjLWptP7bsUmDwEh4hzh0Cy3KpOxlYBWB8bJQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-net": "1.2.9",
+            "web3-utils": "1.2.9"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.19.13",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.13.tgz",
+              "integrity": "sha512-qdixo2f0U7z6m0UJUugTJqVF94GNDkdgQhfBtMs8t5898JE7G/D2kJYw4rc1nzjIPLVAsDkY2MdABnLAP5lM1w==",
+              "dev": true
+            }
+          }
+        },
+        "web3-net": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.9.tgz",
+          "integrity": "sha512-d2mTn8jPlg+SI2hTj2b32Qan6DmtU9ap/IUlJTeQbZQSkTLf0u9suW8Vjwyr4poJYXTurdSshE7OZsPNn30/ZA==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.9.tgz",
+          "integrity": "sha512-F956tCIj60Ttr0UvEHWFIhx+be3He8msoPzyA44/kfzzYoMAsCFRn5cf0zQG6al0znE75g6HlWVSN6s3yAh51A==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.9",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.9.tgz",
+          "integrity": "sha512-NQ8QnBleoHA2qTJlqoWu7EJAD/FR5uimf7Ielzk4Z2z+m+6UAuJdJMSuQNj+Umhz9L/Ys6vpS1vHx9NizFl+aQ==",
+          "dev": true,
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.9.tgz",
+          "integrity": "sha512-6+UpvINeI//dglZoAKStUXqxDOXJy6Iitv2z3dbgInG4zb8tkYl/VBDL80UjUg3ZvzWG0g7EKY2nRPEpON2TFA==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "^4.0.0",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9",
+            "websocket": "^1.0.31"
+          },
+          "dependencies": {
+            "eventemitter3": {
+              "version": "4.0.7",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+              "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+              "dev": true
+            }
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.9.tgz",
+          "integrity": "sha512-PWa8b/EaxaMinFaxy6cV0i0EOi2M7a/ST+9k9nhyhCjVa2vzXuNoBNo2IUOmeZ0WP2UQB8ByJ2+p4htlJaDOjA==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-net": "1.2.9"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
+          "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "@trufflesuite/chromafi": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/chromafi/-/chromafi-2.2.2.tgz",
+      "integrity": "sha512-mItQwVBsb8qP/vaYHQ1kDt2vJLhjoEXJptT6y6fJGvFophMFhOI/NsTVUa0nJL1nyMeFiS6hSYuNVdpQZzB1gA==",
+      "dev": true,
+      "requires": {
+        "ansi-mark": "^1.0.0",
+        "ansi-regex": "^3.0.0",
+        "array-uniq": "^1.0.3",
+        "camelcase": "^4.1.0",
+        "chalk": "^2.3.2",
+        "cheerio": "^1.0.0-rc.2",
+        "detect-indent": "^5.0.0",
+        "he": "^1.1.1",
+        "highlight.js": "^10.4.1",
+        "lodash.merge": "^4.6.2",
+        "min-indent": "^1.0.0",
+        "strip-ansi": "^4.0.0",
+        "strip-indent": "^2.0.0",
+        "super-split": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
       }
     },
     "@trufflesuite/eth-json-rpc-filters": {
@@ -3732,6 +4893,36 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+    },
+    "ansi-mark": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ansi-mark/-/ansi-mark-1.0.4.tgz",
+      "integrity": "sha1-HNS6jVfxXxCdaq9uycqXhsik7mw=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0",
+        "array-uniq": "^1.0.3",
+        "chalk": "^2.3.2",
+        "strip-ansi": "^4.0.0",
+        "super-split": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -5073,6 +6264,16 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "cbor": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
+      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.0.1",
+        "nofilter": "^1.0.4"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -5099,6 +6300,158 @@
       "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
       "requires": {
         "functional-red-black-tree": "^1.0.1"
+      }
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.5.tgz",
+      "integrity": "sha512-yoqps/VCaZgN4pfXtenwHROTp8NG6/Hlt4Jpz2FEP0ZJQ+ZUkVDd0hAPDNKhj3nakpfPt/CNs57yEtxD1bXQiw==",
+      "dev": true,
+      "requires": {
+        "cheerio-select-tmp": "^0.1.0",
+        "dom-serializer": "~1.2.0",
+        "domhandler": "^4.0.0",
+        "entities": "~2.1.0",
+        "htmlparser2": "^6.0.0",
+        "parse5": "^6.0.0",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
+          "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+          "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+          "dev": true
+        },
+        "domhandler": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.1.0"
+          }
+        },
+        "domutils": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
+          "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.0.tgz",
+          "integrity": "sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.4.4",
+            "entities": "^2.0.0"
+          }
+        },
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+          "dev": true
+        }
+      }
+    },
+    "cheerio-select-tmp": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cheerio-select-tmp/-/cheerio-select-tmp-0.1.1.tgz",
+      "integrity": "sha512-YYs5JvbpU19VYJyj+F7oYrIE2BOll1/hRU7rEy/5+v9BzkSo3bK81iAeeQEMI92vRIxz677m72UmJUiVwwgjfQ==",
+      "dev": true,
+      "requires": {
+        "css-select": "^3.1.2",
+        "css-what": "^4.0.0",
+        "domelementtype": "^2.1.0",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.4.4"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
+          "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
+          "dev": true,
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^4.0.0",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.4.3",
+            "nth-check": "^2.0.0"
+          }
+        },
+        "css-what": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
+          "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
+          "dev": true
+        },
+        "dom-serializer": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
+          "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+          "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+          "dev": true
+        },
+        "domhandler": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.1.0"
+          }
+        },
+        "domutils": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
+          "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0"
+          }
+        },
+        "nth-check": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+          "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+          "dev": true,
+          "requires": {
+            "boolbase": "^1.0.0"
+          }
+        }
       }
     },
     "chokidar": {
@@ -5720,6 +7073,12 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==",
+      "dev": true
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -6299,6 +7658,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
       "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
+    },
+    "detect-indent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+      "dev": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -7850,6 +9215,20 @@
         "scrypt-js": "^3.0.0",
         "secp256k1": "^4.0.1",
         "setimmediate": "^1.0.5"
+      }
+    },
+    "ethereum-ens": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ethereum-ens/-/ethereum-ens-0.8.0.tgz",
+      "integrity": "sha512-a8cBTF4AWw1Q1Y37V1LSCS9pRY4Mh3f8vCg5cbXCCEJ3eno1hbI/+Ccv9SZLISYpqQhaglP3Bxb/34lS4Qf7Bg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.4.7",
+        "eth-ens-namehash": "^2.0.0",
+        "js-sha3": "^0.5.7",
+        "pako": "^1.0.4",
+        "underscore": "^1.8.3",
+        "web3": "^1.0.0-beta.34"
       }
     },
     "ethereum-protocol": {
@@ -9405,6 +10784,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "highlight.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
+      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==",
+      "dev": true
+    },
+    "highlightjs-solidity": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-1.0.20.tgz",
+      "integrity": "sha512-Ixb87/4huazRJ7mriimL0DP2GvE5zgSk11VdMPGKMQCNwszDe8qK0PySySsuB88iXyDT/H2gdmvC2bgfrOi3qQ==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -12311,6 +13702,18 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
+    },
     "lodash.flatmap": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
@@ -12321,10 +13724,28 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.partition": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "integrity": "sha1-o45GtzRp4EILDaEhLmbUFL42S6Q=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "lodash.sum": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.sum/-/lodash.sum-4.0.2.tgz",
+      "integrity": "sha1-rZDjl5ZdgD1PH/eqWy0Bl/O0Y3s=",
+      "dev": true
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -13503,6 +14924,12 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
       "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
     },
+    "nofilter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -13982,6 +15409,23 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+    },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "requires": {
+        "parse5": "^6.0.1"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+          "dev": true
+        }
+      }
     },
     "parseurl": {
       "version": "1.3.3",
@@ -17918,6 +19362,12 @@
         }
       }
     },
+    "super-split": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/super-split/-/super-split-1.1.0.tgz",
+      "integrity": "sha512-I4bA5mgcb6Fw5UJ+EkpzqXfiuvVGS/7MuND+oBxNFmxu3ugLNrdIatzBLfhFRMVMLxgSsRy+TjIktgkF9RFSNQ==",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -21193,6 +22643,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "web3modal": "^1.9.2"
   },
   "devDependencies": {
+    "@openzeppelin/contract-loader": "^0.6.2",
     "@openzeppelin/contracts": "^3.3.0",
     "@tailwindcss/forms": "^0.2.1",
+    "@truffle/contract": "^4.3.5",
     "@truffle/hdwallet-provider": "^1.2.0",
     "autoprefixer": "^9.8.6",
     "dotenv": "^8.2.0",

--- a/src/web3/chains.js
+++ b/src/web3/chains.js
@@ -15,7 +15,7 @@ const useAddresses = chainId => {
       })
     } else if (chainId === 1) {
       setAddresses({
-        liquidityMining: '0xF6eaD7c9Bc26b7641B7310EB7Ef6C2040f16ADEf'
+        liquidityMining: '0x7A9A0d2ae824Ba57a5FE7DabAF7E6846021D4e8e'
       })
     }
   }, [chainId])

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,73 @@
+// src/index.js
+const Web3 = require('web3');
+const { setupLoader } = require('@openzeppelin/contract-loader');
+const BN = Web3.utils.BN
+
+const from = "0x85b931a32a0725be14285b66f1a22178c672d69b"
+const usdcAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+const usdtAddress = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+const daiAddress = '0x6b175474e89094c44da98b954eedeac495271d0f'
+
+function timeout(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function makeBlock(web3) {
+  return new Promise(resolve => {
+    web3.currentProvider.send({ jsonrpc: "2.0", method: "evm_mine", id: Date.now() }, function() { resolve() })
+  })
+}
+
+async function main() {
+  // Set up web3 object
+  const web3 = new Web3('http://localhost:8546')
+  const loader = setupLoader({ 
+    provider: web3, 
+    artifactsDir: './build-contracts',
+    defaultSender: from,
+    defaultGas: 5000000,
+  }).truffle;
+
+  const Sarco = loader.fromArtifact("SarcoMock")
+  const sarco = await Sarco.new()
+  console.log("sarco addy:", sarco.address)
+
+  const LiquidityMining = loader.fromArtifact('LiquidityMining2')
+  const liquidityMining = await LiquidityMining.new(usdcAddress, usdtAddress, daiAddress, sarco.address, from)
+  console.log("liqmin addy:", liquidityMining.address)
+
+  const rewardAmount = (new BN(1000000)).mul(new BN(10).pow(new BN(18)))
+
+  await sarco.transfer(liquidityMining.address, rewardAmount)
+  
+  await makeBlock(web3)
+  const currentTime = (await web3.eth.getBlock('latest')).timestamp
+  const startTime = currentTime + 1
+  const endTime = startTime + 60 * 10
+  await liquidityMining.deposit(rewardAmount, startTime, endTime)
+  
+  await timeout(2000)
+
+  const usdcAmount = (new BN(100)).mul(new BN(10).pow(new BN(6)))
+  const usdtAmount = (new BN(100)).mul(new BN(10).pow(new BN(6)))
+  const daiAmount = (new BN(100)).mul(new BN(10).pow(new BN(18)))
+
+  const ERC20 = loader.fromArtifact("ERC20")
+  const usdc = await ERC20.at(usdcAddress)
+  const usdt = await ERC20.at(usdtAddress)
+  const dai = await ERC20.at(daiAddress)
+
+  await usdc.approve(liquidityMining.address, usdcAmount.mul(new BN(2)))
+  await usdt.approve(liquidityMining.address, usdtAmount.mul(new BN(2)))
+  await dai.approve(liquidityMining.address, daiAmount.mul(new BN(2)))
+
+  await liquidityMining.stake(usdcAmount, 0, 0)
+  await liquidityMining.stake(0, usdtAmount, 0)
+  await liquidityMining.stake(0, 0, daiAmount)
+  await liquidityMining.stake(usdcAmount, usdtAmount, daiAmount)
+
+  console.log("Done")
+  process.exit(0)
+}
+
+main();


### PR DESCRIPTION
There was a bug on `mainnet`.

## Background

The [`USDT` contract](https://etherscan.io/address/0xdac17f958d2ee523a2206206994597c13d831ec7#contracts) does not have a standard ERC20 implementation of its `transferFrom` function. Notably, calling the `transferFrom` function on `USDT`, from within a smart contract, via an `IERC20` object loaded from the [standard ERC20 interface implementation](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md#transferfrom), will revert and fail.

There is not much documentation on the internet about this, but it has been [experienced and described before](https://ethereum.stackexchange.com/a/89567/41394).

## The Bug

We noticed right away that transactions were failing after liquidity mining went live on https://mining.sarcophagus.io. After coming to the conclusion that these transactions _should_ have been working, we disabled the frontend from allowing any new stablecoin locks. Of course, people could still interact with the contract directly, but blocking the frontend gave us time to research what was wrong.

Our [initial implementation](https://github.com/sarcophagus-org/liquidity-mining/blob/master/contracts/LiquidityMining.sol) of `LiquidityMining` made the incorrect assumption that [OpenZeppelin's `ERC20` implementation](https://github.com/sarcophagus-org/liquidity-mining/blob/master/contracts/LiquidityMining.sol#L7) would allow [proper `transferFrom` behavior with `USDT`](https://github.com/sarcophagus-org/liquidity-mining/blob/master/contracts/LiquidityMining.sol#L233).

As we found out, in production, this is not the case. [Any](https://etherscan.io/tx/0xfffc26e9e3e303e639a892732f5b25d7b1340d9d459100fd8671651e76f7f8d7) [attempt](https://etherscan.io/tx/0x59663e9c764ddc423a9a61c6608f64b9cb0560c9f5149fb1fcca20846a3d0c48) at [staking](https://etherscan.io/tx/0xfcbb0b23e362e2ae1f3101f40edb2f0ec4550b0bf6c578ab1341043d788a9ece)/[locking](https://etherscan.io/tx/0xb6eeebc38615fdc47c59eac324aa7657abbc6a1ca573b9ff32a098a089358d72) `USDT` [resulted](https://etherscan.io/tx/0x19dae399ffe3ae3767bea9165b0735bc7c5f78da83160ee67716638026241d99) in the [transaction](https://etherscan.io/tx/0x3b8968cbd49079f112a470fa7e771423724c39ec915e3d12e897183cce21a087) [reverting](https://etherscan.io/tx/0x0bcb5451d8e6c8c45732faf18362b2122f7097cabbb5b88b95675afed177ba67).

## The Fix

### Technically

Thankfully, the technical fix was quite simple. OpenZeppelin has a library called `SafeERC20` which implements a function called `safeTransferFrom`, that does play nicely with `USDT`'s `transferFrom` function.

The technical fix simply involved:
* creating a new version of `LiquidityMining`, called [`LiquidityMining2`](https://github.com/sarcophagus-org/liquidity-mining/blob/master/contracts/LiquidityMining2.sol) (copy and paste)
* [importing the `SafeERC20` library](https://github.com/sarcophagus-org/liquidity-mining/blob/master/contracts/LiquidityMining2.sol#L8) into `LiquidityMining2`
* [overloading the ERC20 type](https://github.com/sarcophagus-org/liquidity-mining/blob/master/contracts/LiquidityMining2.sol#L14) with these new `safe` functions
* [using these new `safe` functions](https://github.com/sarcophagus-org/liquidity-mining/blob/master/contracts/LiquidityMining2.sol#L230-L240) when transferring stablecoins from a user, into the contract

#### Why wasn't this caught earlier?

Our initial testing used [mocked-out versions](https://github.com/sarcophagus-org/liquidity-mining/tree/master/contracts/mocks) of `USDC`/`USDT`/`DAI`. That is, we didn't use the actual deployed stablecoin contracts on mainnet, but instead created and deployed our own basic `ERC20` tokens (locally, and on testnets).

So that's why it didn't come up during testing. We were assuming that these stablecoins all had standard `ERC20` interface implementations, but `USDT` does not.

#### How do we know the fix works?

After implementing the `SafeERC20` fix, we [wrote a test](https://github.com/sarcophagus-org/liquidity-mining/blob/master/test/index.js) that forks the `mainnet` state (so that we can use the _actual_ stablecoin contracts), and then re-created the error on our original `LiquidityMining` contract. This worked, so now we know that we locally see the error that is happening on `mainnet`.

Then, we tested that the exact same code does _not_ error out when using the new and improved `LiquidityMining2` contract.

And it worked!

We feel much more confident now, after learning how to locally fork `mainnet` state and run test scripts against it.

### Socially

This was a bigger issue.

We implemented the `LiquidityMining` contract in a very trustless way. Once you lock some stablecoins in it, there is nothing that we can do to stop `SARCO` token reward generation.

We wanted to avoid needing to re-deploy the `SARCO` token to mainnet. That would be a big mess, since we've already distributed those tokens to their [various destinations](https://sarcophagus.io/sarco_token.html), and deploying _another_ `SARCO` token would show double balances in wallets (because now there are two `SARCO` `ERC20` tokens).

Problem was, we had already [sent 1MM `SARCO` tokens to the `LiquidityMining` contract](https://etherscan.io/tx/0xcdd0bcad68ec786e4efea866fe8ec79fa4f81cbf1f32cb6b2b65d404daed9c77). There is no way to take those tokens back (for the purpose of giving to the _new_ `LiquidityMining2` contract) as long as people had locked stablecoins (which they had). If those  `SARCO` tokens were stuck in the `LiquidityMining` contract for good, then we'd need to redeploy the `SARCO` token contract :(

However, we did build [one failsafe](https://github.com/sarcophagus-org/liquidity-mining/blob/master/contracts/LiquidityMining.sol#L413-L446) into `LiquidityMining`, which ended up being our saving grace. 

If there are 0 people with locked stablecoins, we can "recover" any `SARCO` tokens that are in the contract. This is ok, because if users unlock their stablecoins, their `SARCO` rewards are transferred to them automatically. So if there are 0 users with locked stablecoins, that means that none of the `SARCO` in the `LiquidityMining` contract belongs to anyone.

Thankfully, our pleas on Telegram and Discord worked. Everyone who had locked, ended up unlocking and pulling their stablecoins and accumulated `SARCO` rewards. [We recovered](https://etherscan.io/tx/0xf154394ed6479400a5845f2d9ccb647c433fe6faf88350a7013940450af7a4ec) the ~997,974 remaining `SARCO` tokens, use the founder's `SARCO` distribution to [top them back up to 1MM](https://etherscan.io/tx/0x95753eab8167cfda9ac614df438b0809a977b0ea4c460db3cb284ef41be53f43), and [sent them to `LiquidityMining2`](https://etherscan.io/tx/0x8dc3717b0960c6076649157d5b541e593a6532dc76aaf0ac354ee5275594be28) to be used as the rewards in the [fixed version of the liquidity mining system](https://etherscan.io/address/0x7a9a0d2ae824ba57a5fe7dabaf7e6846021d4e8e#code).

## Moving Forward

Our biggest takeaway is that we should have tried harder to replicate the `mainnet` environment during testing. We assumed that the `mainnet` deployments of the 3rd party contracts that we'd be interacting with, followed the spec like they were supposed to. Whoops!

As we continue building, testing, and deploying the rest of the Sarcophagus system, we'll update our test suites to use a forked version of `mainnet`, as the underlying blockchain that the test scripts run on.

We were very lucky this time. No user funds were lost, we avoided needing to redeploy the `SARCO` token, and the `LiquidityMining` contract was fixed and deployed within a 24 hour period from noticing the `USDT` bug.

If you're reading this, thanks for understanding.

Thanks to the community for your cooperation, and _especially_ big thanks to those who were participating in liquidity mining and unlocked your coins at our request, so that we could safely recover the remainder of the `SARCO` reward tokens.

Our obvious goal is to avoid any issues like this on mainnet in the future, and are extremely grateful that the issue encountered here didn't have worse consequences.

_knock on wood_